### PR TITLE
Intro Bootstrap Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ Currently does not work.
 
 * https://startbootstrap.com/template-overviews/bare/
 * https://github.com/twbs/bootstrap-sass
+* https://github.com/thoughtbot/high_voltage

--- a/teamworkApp/Gemfile
+++ b/teamworkApp/Gemfile
@@ -13,7 +13,7 @@ gem 'sqlite3'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use bootstrap for UI aid
-gem 'bootstrap-sass', '~> 3.1.1'
+gem 'bootstrap-sass', '~> 3.2.0'
 # Use jquery for site support
 gem 'jquery-rails'
 # Use SCSS for stylesheets
@@ -22,6 +22,9 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
+
+# for static pages https://github.com/thoughtbot/high_voltage, html for these pages in app/views/pages/<id>
+gem 'high_voltage', '~> 3.0.0'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'

--- a/teamworkApp/Gemfile.lock
+++ b/teamworkApp/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     bindex (0.5.0)
-    bootstrap-sass (3.1.1.1)
+    bootstrap-sass (3.2.0.2)
       sass (~> 3.2)
     builder (3.2.3)
     byebug (9.1.0)
@@ -69,6 +69,7 @@ GEM
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    high_voltage (3.0.0)
     i18n (0.8.6)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -183,10 +184,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bootstrap-sass (~> 3.1.1)
+  bootstrap-sass (~> 3.2.0)
   byebug
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
+  high_voltage (~> 3.0.0)
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/teamworkApp/app/views/layouts/application.html.erb
+++ b/teamworkApp/app/views/layouts/application.html.erb
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>Teamwork Analysis</title>
-  <%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true %>
-  <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
-  <%= csrf_meta_tags %>
-</head>
-<body>
-	  <h1> Hello, welcome to our teamwork site :) </h1>
-	  <style>body{padding-top:70px;}</style>
-	</body>
-	</html>
+  <head>
+    <title>TeamworkApp</title>
+    <%= csrf_meta_tags %>
+
+    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/teamworkApp/app/views/pages/home.html.erb
+++ b/teamworkApp/app/views/pages/home.html.erb
@@ -7,7 +7,30 @@
   <%= csrf_meta_tags %>
 </head>
 <body>
-	  <h1> Hello, welcome to our teamwork site :) </h1>
-	  <style>body{padding-top:70px;}</style>
+	  <center><h1> Teamwork Analysis </h1></center>
+    <style>body{padding-top:70px;}</style>
+    <div class="container">
+      <div class="row">
+        <div class="col-lg-12">
+          <center> - - - </center>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-lg-12">
+          <center> - - - </center>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-lg-12">
+          <center> - - - </center>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-4"><center><a href="#" class="btn btn-info" role="button">Overall Distribution</a></center></div>
+        <div class="col-md-4"><center><a href="#" class="btn btn-info" role="button">Create Teams</a></center></div>
+        <div class="col-md-4"><center><a href="#" class="btn btn-info" role="button">Individual Statistics</a></center></div>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/teamworkApp/app/views/pages/home.html.erb
+++ b/teamworkApp/app/views/pages/home.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Teamwork Analysis</title>
+  <%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true %>
+  <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+  <%= csrf_meta_tags %>
+</head>
+<body>
+	  <h1> Hello, welcome to our teamwork site :) </h1>
+	  <style>body{padding-top:70px;}</style>
+</body>
+</html>

--- a/teamworkApp/config/routes.rb
+++ b/teamworkApp/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root 'high_voltage/pages#show', id: 'home'
 end


### PR DESCRIPTION
This pull request is about the installation a creation of an intro page.

First bootstrap was installed using [this](https://github.com/twbs/bootstrap-sass) guide. I directly followed the guide, and everything was successfully installed.

Next, a static page app called 'high-voltage' was installed from [this](https://github.com/thoughtbot/high_voltage) page. This installation went smoothly as well.

I set the app/views/layouts/application.html.erb file to be a blank intro file as of now, to allow our static pages' layout to be our main controller for now. If we decide to add a navbar or anything, that can be addressed using this file.

I then created app/views/pages/home.html.erb. This page looks like 
![screen shot 2017-10-15 at 12 38 11 pm](https://user-images.githubusercontent.com/27705421/31588476-f0d64516-b1a6-11e7-8987-e5d7325b2f16.png). As of now, these links do not direct anywhere. 

The root page of our site is directed to the above display. This is configured in routes.rb, where it is specified that the root should be redirected to the home page.

Thanks!
